### PR TITLE
3/16 9:33 RecruitList GET 요청에 대해 동적 SQL 적용

### DIFF
--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/board/controller/BoardController.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/board/controller/BoardController.java
@@ -42,7 +42,9 @@ public class BoardController {
 
 	// 커뮤니티 전체 게시글 가져오기
 	@GetMapping("/article")
-	public ResponseEntity<BasicResponseEntity<Object>> getCommunityList(@RequestParam("page") int page, @RequestParam("size") int size, Authentication authentication) {
+	public ResponseEntity<BasicResponseEntity<Object>> getCommunityList(@RequestParam("page") int page,
+			@RequestParam("size") int size, 
+			@RequestParam("")Authentication authentication) {
 		PagingEntity criteria = new PagingEntity();
 		criteria.setpageNum(page);
 		criteria.setAmount(size);

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/controller/RecruitController.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/controller/RecruitController.java
@@ -14,6 +14,7 @@ import org.ppiyung.ppiyung.recruit.service.RecruitService;
 import org.ppiyung.ppiyung.recruit.vo.Apply;
 import org.ppiyung.ppiyung.recruit.vo.BookMark;
 import org.ppiyung.ppiyung.recruit.vo.Recruit;
+import org.ppiyung.ppiyung.recruit.vo.RecruitOption;
 import org.ppiyung.ppiyung.recruit.vo.Suggest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -135,16 +136,27 @@ public class RecruitController {
 	
 	// 전체 채용 공고 조회 
 	@GetMapping(value="")
-	public ResponseEntity<BasicResponseEntity<Object>> 
-	getRecruitList(@RequestParam("pagenum") int pageNum, @RequestParam("amount") int amount){ 
+	public ResponseEntity<BasicResponseEntity<Object>> getRecruitList(@RequestParam("page") int pageNum,
+			@RequestParam("size") int amount,
+			@RequestParam(value = "workArea", defaultValue = "0") int workAreaId,
+			@RequestParam(value = "company", defaultValue = "") String companyId,
+			@RequestParam(value = "keyword", defaultValue = "") String keyword,
+			@RequestParam(value = "closed", defaultValue = "false") boolean closed){ 
   		
-		log.debug(pageNum + " " + amount );
-		PagingEntity pagingEntity = new PagingEntity();
-		pagingEntity.setpageNum(pageNum);
-		pagingEntity.setAmount(amount);
+		RecruitOption option = new RecruitOption(pageNum, amount);
+		option.setRecruitId(0);
+		option.setIncludeClosed(closed);
+		if (workAreaId != 0) {
+			option.setWorkAreaId(workAreaId);
+		}
+		if (!companyId.equals("")) {
+			option.setCompanyId(companyId);
+		}
+		if (!keyword.equals("")) {
+			option.setKeyword(keyword);
+		}
 		
-		
-        List<Recruit> result = service.getRecruitList(pagingEntity);
+		List<Recruit> result = service.getRecruitList(option);	
         log.debug("!!" + result);
 		BasicResponseEntity<Object> respBody = null;
 		int respCode=0;
@@ -165,68 +177,6 @@ public class RecruitController {
 		
 		return new ResponseEntity<BasicResponseEntity<Object>>(respBody, headers, respCode);
 		
-	}
-	
-	// 직무별 채용공고 조회
-	@GetMapping(value="/workarea/{work_area_id}")
-	public ResponseEntity<BasicResponseEntity<Object>> 
-		getRecruitListByWorkAreaId(@PathVariable("work_area_id") int work_area_id){ 
-		
-		log.debug(work_area_id);
-		
-		List<Recruit> result = service.getRecruitListByWorkAreaId( work_area_id );
-		
-		BasicResponseEntity<Object> respBody = null;
-		int respCode=0;
-		
-		if(result != null) {
-			log.debug("직무별 공고 조회 성공");
-			respBody = new BasicResponseEntity<Object> (true, "직무별 공고 조회 완료", result);
-			respCode = HttpServletResponse.SC_OK;
-		} else {
-			log.debug("직무별 공고 조회 실패");
-			respBody = new BasicResponseEntity<Object> (false, "직무별 공고 조회 실패", result);
-			respCode = HttpServletResponse.SC_BAD_REQUEST;
-		}
-		
-		
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(new MediaType("application", "json",
-				Charset.forName("UTF-8")));
-		
-		return new ResponseEntity<BasicResponseEntity<Object>>(respBody, headers, respCode);
-
-      }
-	
-	// 키워드로 채용공고 조회(제목+본문 검색)
-	@GetMapping(value="/{keyword}")
-	public ResponseEntity<BasicResponseEntity<Object>> 
-		getRecruitListByKeyword(@PathVariable("keyword") String keyword){ 
-		
-		log.debug(keyword);
-		
-		List<Recruit> result = service.getRecruitListByKeyword(keyword);
-		
-		BasicResponseEntity<Object> respBody = null;
-		int respCode=0;
-		
-		if(result != null) {
-			log.debug("공고 조회 성공");
-			respBody = new BasicResponseEntity<Object> (true, "공고 조회 완료", result);
-			respCode = HttpServletResponse.SC_OK;
-		} else {
-			log.debug("공고 조회 실패");
-			respBody = new BasicResponseEntity<Object> (false, "공고 조회 실패", result);
-			respCode = HttpServletResponse.SC_BAD_REQUEST;
-		}
-		
-		
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(new MediaType("application", "json",
-				Charset.forName("UTF-8")));
-		
-		return new ResponseEntity<BasicResponseEntity<Object>>(respBody, headers, respCode);
-
 	}
 	
 	// 기업별 채용 공고 현황 조회 
@@ -518,8 +468,9 @@ public class RecruitController {
 		return new ResponseEntity<BasicResponseEntity<Object>>(respBody, headers, respCode);
 
 	}
+    
     //채용공고 상세조회
-	 @GetMapping(value="/recruitDetail/{recruit_id}")
+	 @GetMapping(value="/{recruit_id}")
 	 public ResponseEntity<BasicResponseEntity<Object>> 
 	 		getRecruitDetailInfo(@PathVariable("recruit_id") String recruitId) {
 		 

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/dao/RecruitDao.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/dao/RecruitDao.java
@@ -7,6 +7,7 @@ import org.ppiyung.ppiyung.common.entity.PagingEntity;
 import org.ppiyung.ppiyung.recruit.vo.Apply;
 import org.ppiyung.ppiyung.recruit.vo.BookMark;
 import org.ppiyung.ppiyung.recruit.vo.Recruit;
+import org.ppiyung.ppiyung.recruit.vo.RecruitOption;
 import org.ppiyung.ppiyung.recruit.vo.Suggest;
 
 public interface RecruitDao {
@@ -14,7 +15,7 @@ public interface RecruitDao {
 	public void insertRecruitNotice(Recruit recruit) throws Exception;
 	public void updateRecruitNotice(Recruit recruit) throws Exception;
 	public void updateRecruitEndDate(int recruitId) throws Exception;
-	public List<Recruit> selectAll(PagingEntity pagingEntity);
+	public List<Recruit> selectAll(RecruitOption option);
 	public List<Recruit> selectByWorkAreaId(int work_area_id);
 	public List<Recruit> selectByKeyword(String keyword);
 	public HashMap<String, Object> selectByCompany(String companyId);

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/dao/RecruitDaoImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/dao/RecruitDaoImpl.java
@@ -9,6 +9,7 @@ import org.ppiyung.ppiyung.recruit.vo.Apply;
 import org.ppiyung.ppiyung.recruit.vo.BookMark;
 import org.ppiyung.ppiyung.recruit.vo.Recruit;
 import org.ppiyung.ppiyung.recruit.vo.RecruitBookMark;
+import org.ppiyung.ppiyung.recruit.vo.RecruitOption;
 import org.ppiyung.ppiyung.recruit.vo.Suggest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -53,8 +54,8 @@ public class RecruitDaoImpl implements RecruitDao {
 
 	@Override
 
-	public List<Recruit> selectAll(PagingEntity pagingEntity) {
-        List<Recruit> list = session.selectList("org.ppiyung.ppiyung.recruit.selectAll", pagingEntity);
+	public List<Recruit> selectAll(RecruitOption option) {
+        List<Recruit> list = session.selectList("org.ppiyung.ppiyung.recruit.select", option);
 		return list;
 	}
 

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/service/RecruitService.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/service/RecruitService.java
@@ -8,6 +8,7 @@ import org.ppiyung.ppiyung.recruit.vo.Apply;
 import org.ppiyung.ppiyung.recruit.vo.BookMark;
 import org.ppiyung.ppiyung.recruit.vo.Recruit;
 import org.ppiyung.ppiyung.recruit.vo.RecruitBookMark;
+import org.ppiyung.ppiyung.recruit.vo.RecruitOption;
 import org.ppiyung.ppiyung.recruit.vo.Suggest;
 
 public interface RecruitService {
@@ -18,10 +19,12 @@ public interface RecruitService {
 
 	public boolean closeRecruitNotice(int recruitId);
 	
-    public List<Recruit> getRecruitList(PagingEntity pagingEntity);
+    public List<Recruit> getRecruitList(RecruitOption option);
 	
+    @Deprecated
     public List<Recruit> getRecruitListByWorkAreaId(int work_area_id);
 
+    @Deprecated
 	public List<Recruit> getRecruitListByKeyword(String keyword);
 
 	public HashMap<String, Object> getRecruitStatusOfCompany(String companyId);
@@ -49,9 +52,5 @@ public interface RecruitService {
 	public List<Suggest> getJobOfferOfCompany(String companyId);
 
 
-
-
-	
-	
 	
 }

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/service/RecruitServiceImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/service/RecruitServiceImpl.java
@@ -9,6 +9,7 @@ import org.ppiyung.ppiyung.recruit.vo.Apply;
 import org.ppiyung.ppiyung.recruit.vo.BookMark;
 import org.ppiyung.ppiyung.recruit.vo.Recruit;
 import org.ppiyung.ppiyung.recruit.vo.RecruitBookMark;
+import org.ppiyung.ppiyung.recruit.vo.RecruitOption;
 import org.ppiyung.ppiyung.recruit.vo.Suggest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -53,11 +54,11 @@ public class RecruitServiceImpl implements RecruitService{
 	}
 	
 	@Override
-	public List<Recruit> getRecruitList(PagingEntity pagingEntity) {
-		List<Recruit> list = dao.selectAll(pagingEntity);
+	public List<Recruit> getRecruitList(RecruitOption option) {
+		List<Recruit> list = dao.selectAll(option);
 		return list;
 	}
-	
+
 	@Override
 	public  List<Recruit> getRecruitListByWorkAreaId(int work_area_id) {
 		List<Recruit> list = dao.selectByWorkAreaId(work_area_id);

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/vo/RecruitOption.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/recruit/vo/RecruitOption.java
@@ -1,0 +1,53 @@
+package org.ppiyung.ppiyung.recruit.vo;
+
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+public class RecruitOption {
+
+	private int recruitId;
+	private String companyId;
+	private String keyword;
+	private int workAreaId;
+	private boolean includeClosed;
+	
+	/* 현재 페이지 */
+	private int pageNum;
+
+	/* 한 페이지 당 보여질 게시물 갯수 */
+	private int amount;
+	
+	// 참고) https://kimvampa.tistory.com/170,  https://kimvampa.tistory.com/173?category=843151
+
+    private int skip; 	// 스킵 할 게시물 수 의미( (pageNum-1) * amount ) 
+	// ex) 1page 에서 보여줄 게시물은 가장 최근꺼부터 (1) ~ (10)번쨰 게시글 
+	// ex) 2page 에서 보여줄 게시물은  (11)번째 게시물 부터 ~ 20 번째 게시물
+    
+    
+	/* 기본 생성자 -> 기봅 세팅 : pageNum = 1, amount = 10 */
+	public RecruitOption() {
+		this(1, 10);
+	}
+
+	/* 생성자 => 원하는 pageNum, 원하는 amount */
+	public RecruitOption(int pageNum, int amount) {
+		this.pageNum = pageNum;
+		this.amount = amount;
+	}
+
+	public void setpageNum(int pageNum) {
+		this.skip = (pageNum-1) * this.amount;
+		this.pageNum = pageNum;
+	}
+	
+	public void setAmount(int amount) {
+		this.skip = (this.pageNum-1) * amount;
+		this.amount = amount;
+	}
+}

--- a/ppiyung/src/main/resources/mappers/RecruitMapper.xml
+++ b/ppiyung/src/main/resources/mappers/RecruitMapper.xml
@@ -45,8 +45,49 @@
 		  ]]>
 	   </update>
 	   
-	   <!-- 전체 채용 공고 조회 -->
+   	   <select id="select" parameterType="RecruitOption" resultMap="RecruitMapped">
+         SELECT r.*, m.member_name FROM recruit_tb AS r
+         JOIN member_tb AS m
+            ON r.company_id=m.member_id
+         <where>
+         	<if test="recruitId != 0">
+         		recruit_id = #{recruitId}
+         	</if>
+         	<if test="companyId != null">
+         		AND company_id = #{companyId}
+         	</if>
+         	<if test="keyword != null">
+         		AND (recruit_title LIKE CONCAT ('%',#{keyword},'%') OR recruit_detail LIKE CONCAT ('%',#{keyword},'%'))
+         	</if>
+         	<if test="workAreaId != 0">
+         		AND r.work_area_id = #{workAreaId}
+         	</if>
+         	<if test="includeClosed == false">
+         		<![CDATA[
+	         		AND r.recruit_start_at <= NOW() AND r.recruit_end_at >= NOW()
+         		]]>
+         	</if>
+         </where>
+         ORDER BY recruit_id DESC
+         <if test="skip != null and amount != null">
+         	LIMIT #{skip}, #{amount}
+         </if>
+	   </select>
+	   
+	   <!-- 전체 채용 공고 조회 (마감 공고 포함 안함) -->
 	   <select id="selectAll" parameterType="PagingEntity" resultMap="RecruitMapped">
+	      <![CDATA[
+	         SELECT r.*, m.member_name FROM recruit_tb AS r
+	         JOIN member_tb AS m
+             ON r.company_id=m.member_id
+             WHERE r.recruit_start_at <= NOW() AND r.recruit_end_at >= NOW()
+	         ORDER BY recruit_id DESC
+	         LIMIT #{skip}, #{amount}
+	      ]]>
+	   </select>
+	   	   
+	   <!-- 전체 채용 공고 조회 (마감 공고 포함) -->
+	   <select id="selectAllIncludeClosed" parameterType="PagingEntity" resultMap="RecruitMapped">
 	      <![CDATA[
 	         SELECT r.*, m.member_name FROM recruit_tb AS r
 	         JOIN member_tb AS m
@@ -56,7 +97,7 @@
 	      ]]>
 	   </select>
 	   
-	   <!-- 직무별 채용 공고 조회 -->
+	   <!-- 직무별 채용 공고 조회 (마감 공고 포함 안함) -->
 	   <select id="selectByWorkAreaId" parameterType="Integer" resultMap="RecruitMapped">
 	      <![CDATA[
 	         SELECT r.*, m.member_name FROM recruit_tb AS r

--- a/ppiyung/src/main/resources/mybatis-config.xml
+++ b/ppiyung/src/main/resources/mybatis-config.xml
@@ -17,6 +17,7 @@
 		<typeAlias type="org.ppiyung.ppiyung.board.vo.Board" alias="Board"/>
 		<typeAlias type="org.ppiyung.ppiyung.common.entity.PagingEntity" alias="PagingEntity"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.recruit.vo.Recruit" alias="Recruit"/>
+	 	<typeAlias type="org.ppiyung.ppiyung.recruit.vo.RecruitOption" alias="RecruitOption"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.board.vo.Reply" alias="Reply"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.board.vo.Like" alias="Like"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.notify.vo.Notification" alias="Notify"/>


### PR DESCRIPTION
- 채용공고 리스트 조회에 동적 SQL을 적용하였습니다.
- 그 영향으로 API 엔트리포인트 URI가 간소화되었습니다.
    - [GET] /recruit?page={번호}&size={크기}&keyword=(키워드)&workArea=(직무분야ID)&company=(기업회원ID)&closed=(마감공고포함여부)
    - 위의 쿼리스트링에서 page, size를 제외하면 생략하거나 동시에 사용할 수 있습니다.
- recruit/{기업ID} URI가 사라지면서, 공고 상세조회 URI를 recruit/recruitDetail/{채용공고ID}에서,  recruit/{채용공고ID}로 변경하였습니다.