### PR TITLE
회원 관련 변경

### DIFF
--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/controller/MemberController.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/controller/MemberController.java
@@ -226,7 +226,12 @@ public class MemberController {
 		if (userDetails.getUsername().equals(memberId) ||
 				hasAuthority) { // 자신의 정보를 수정하는 경우이거나 관리자인 경우
 			log.debug("회원정보수정 - 권한 확인됨");
+			
 			reqUpdateInfo.setMemberId(memberId);
+			if (reqUpdateInfo.getMemberPw() != null && reqUpdateInfo.getMemberPw().equals("")) {
+				reqUpdateInfo.setMemberPw(null);
+			}
+			
 			result = service.modifyMember(reqUpdateInfo);
 		}
 		

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/controller/MemberController.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.ppiyung.ppiyung.member.service.MemberService;
 import org.ppiyung.ppiyung.member.vo.Image;
 import org.ppiyung.ppiyung.member.vo.Member;
 import org.ppiyung.ppiyung.member.vo.MemberExtended;
+import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -156,27 +157,52 @@ public class MemberController {
 
 	// 관리자 회원 전체조회
 	@GetMapping(value = "")
-	public ResponseEntity<BasicResponseEntity<Object>> 
-				getAllMember(@RequestParam("pagenum") int pageNum, @RequestParam("amount") int amount,Authentication authentication) {
+	public ResponseEntity<BasicResponseEntity<Object>> getAllMember(@RequestParam("page") int pageNum,
+			@RequestParam("size") int amount,
+			@RequestParam(value="memberType", defaultValue = "") String memberType,
+			@RequestParam(value="memberId", defaultValue = "") String memberId,
+			@RequestParam(value="memberName", defaultValue = "") String memberName,
+			@RequestParam(value="noVerified", defaultValue = "false") boolean noVerified,
+			Authentication authentication) {
 		
+		MemberOption option = new MemberOption(pageNum, amount);
+		if (!memberType.equals("")) {
+			option.setMemberType(memberType);
+		}
+		if (!memberId.equals("")) {
+			option.setMemberId(memberId);
+		}
+		if (!memberName.equals("")) {
+			option.setMemberName(memberName);
+		}
+		option.setNoVerified(noVerified);
+
 		BasicResponseEntity<Object> respBody = null;
 		int respCode = 0;
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
-		PagingEntity pagingEntity = new PagingEntity();
-		pagingEntity.setpageNum(pageNum);
-		pagingEntity.setAmount(amount);
-		List<Member> list = service.getAllMember(pagingEntity);
 		
 		UserDetails userDetails = (UserDetails)authentication.getPrincipal();
-		boolean hasAutority = userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
-		if(list != null && hasAutority) {
-			log.debug("관리자-회원전체조회 성공");
-			respBody = new BasicResponseEntity<Object>(true, "전체회원조회 성공하였습니다.", list);
-			respCode = HttpServletResponse.SC_OK;
+		if(userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
+			
+			List<Member> list = service.getAllMember(option);
+			int total = service.getAllMemberCount(option);
+			if (list != null) {
+				log.debug("관리자-회원전체조회 성공");
+				Map<String, Object> payload = new HashMap<String, Object>();
+				payload.put("total", total);
+				payload.put("list", list);
+				
+				respBody = new BasicResponseEntity<Object>(true, "전체회원조회 성공하였습니다.", payload);
+				respCode = HttpServletResponse.SC_OK;
+			} else {
+				log.debug("관리자-회원전체조회 실패"); 
+				respBody = new BasicResponseEntity<Object>(false, "전체회원조회 실패하였습니다.", null);
+				respCode = HttpServletResponse.SC_BAD_REQUEST;
+			}
 		}else {
-			log.debug("관리자-회원전체조회 실패");
-			respBody = new BasicResponseEntity<Object>(false, "전체회원조회 실패하였습니다.", null);
+			log.debug("관리자-회원전체조회 실패 - 권한 없음");
+			respBody = new BasicResponseEntity<Object>(false, "전체회원조회 실패하였습니다. 권한이 없습니다.", null);
 			respCode = HttpServletResponse.SC_BAD_REQUEST;
 		}
 		return new ResponseEntity<BasicResponseEntity<Object>>(respBody, headers, respCode);

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/dao/MemberDao.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/dao/MemberDao.java
@@ -1,12 +1,11 @@
 package org.ppiyung.ppiyung.member.dao;
 
 import java.util.List;
-import java.util.Map;
 
-import org.ppiyung.ppiyung.common.entity.PagingEntity;
 import org.ppiyung.ppiyung.member.vo.Image;
 import org.ppiyung.ppiyung.member.vo.Member;
 import org.ppiyung.ppiyung.member.vo.MemberExtended;
+import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
 
@@ -24,7 +23,9 @@ public interface MemberDao {
 	public void updateInfo(Member member) throws Exception;
 	
 	//관리자일경우 모든회원
-	public List<Member>  getAllMember(PagingEntity pagingEntity);
+	public List<Member>  getAllMember(MemberOption option);
+
+	public int  getAllMemberCount(MemberOption option);
 
 	public void leaveMember(String memberId) throws Exception;
 

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/dao/MemberDaoImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/dao/MemberDaoImpl.java
@@ -1,13 +1,12 @@
 package org.ppiyung.ppiyung.member.dao;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
-import org.ppiyung.ppiyung.common.entity.PagingEntity;
 import org.ppiyung.ppiyung.member.vo.Image;
 import org.ppiyung.ppiyung.member.vo.Member;
 import org.ppiyung.ppiyung.member.vo.MemberExtended;
+import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,11 +57,17 @@ public class MemberDaoImpl implements MemberDao {
 
 
 	@Override
-	public List<Member> getAllMember(PagingEntity pagingEntity) {
-		List<Member> list = session.selectList("org.ppiyung.ppiyung.member.selectAll",pagingEntity);
+	public List<Member> getAllMember(MemberOption option) {
+		List<Member> list = session.selectList("org.ppiyung.ppiyung.member.selectAll", option);
 
 		return list;
 
+	}
+
+
+	@Override
+	public int getAllMemberCount(MemberOption option) {
+		return session.selectOne("org.ppiyung.ppiyung.member.selectAllTotal", option);
 	}
 
 

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberService.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberService.java
@@ -10,6 +10,7 @@ import org.ppiyung.ppiyung.common.entity.PagingEntity;
 import org.ppiyung.ppiyung.member.vo.Image;
 import org.ppiyung.ppiyung.member.vo.Member;
 import org.ppiyung.ppiyung.member.vo.MemberExtended;
+import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +29,9 @@ public interface MemberService {
 	
 	public MemberExtended getMemberInfoJoinned(Member member);
 
-	public List<Member> getAllMember(PagingEntity pagingEntity);
+	public List<Member> getAllMember(MemberOption option);
+	
+	public int getAllMemberCount(MemberOption option);
 
 	public boolean leaveMember(String memberId);
 

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.ServletOutputStream;
@@ -14,12 +13,12 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.ppiyung.ppiyung.common.entity.PagingEntity;
 import org.ppiyung.ppiyung.common.util.JwtTokenUtil;
 import org.ppiyung.ppiyung.member.dao.MemberDao;
 import org.ppiyung.ppiyung.member.vo.Image;
 import org.ppiyung.ppiyung.member.vo.Member;
 import org.ppiyung.ppiyung.member.vo.MemberExtended;
+import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,9 +113,14 @@ public class MemberServiceImpl implements MemberService {
 
 	// 모든 멤버 조회
 	@Override
-	public List<Member> getAllMember(PagingEntity pagingEntity) {
-		List<Member> list = dao.getAllMember(pagingEntity);
+	public List<Member> getAllMember(MemberOption option) {
+		List<Member> list = dao.getAllMember(option);
 		return list;
+	}
+
+	@Override
+	public int getAllMemberCount(MemberOption option) {
+		return dao.getAllMemberCount(option);
 	}
 
 	// 토큰

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
@@ -21,6 +21,7 @@ import org.ppiyung.ppiyung.member.vo.MemberExtended;
 import org.ppiyung.ppiyung.member.vo.MemberOption;
 import org.ppiyung.ppiyung.member.vo.OpenResumeOption;
 import org.ppiyung.ppiyung.member.vo.Resume;
+import org.ppiyung.ppiyung.member.vo.SecurityUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/MemberServiceImpl.java
@@ -84,7 +84,9 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	public boolean modifyMember(Member member) {
 		try {
-			member.setMemberPw(passwordEncoder.encode(member.getMemberPw()));
+			if (member.getMemberPw() != null) {
+				member.setMemberPw(passwordEncoder.encode(member.getMemberPw()));				
+			}
 			dao.updateInfo(member);
 			return true;
 		} catch (Exception e) {

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/SecurityUserDetailService.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/service/SecurityUserDetailService.java
@@ -18,6 +18,12 @@ public class SecurityUserDetailService implements UserDetailsService {
 		try {
 			Member param = new Member();
 			param.setMemberId(userId);
+			
+			Member member = dao.selectMemberId(param);
+			if (!member.isMemberVerified() || !member.isMemberActive()) {
+				throw new Exception();
+			}
+			
 			return new SecurityUserDetails(dao.selectMemberId(param));
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/ppiyung/src/main/java/org/ppiyung/ppiyung/member/vo/MemberOption.java
+++ b/ppiyung/src/main/java/org/ppiyung/ppiyung/member/vo/MemberOption.java
@@ -1,0 +1,51 @@
+package org.ppiyung.ppiyung.member.vo;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+public class MemberOption {
+
+	private String memberId;
+	private String memberType;
+	private String memberName;
+	private boolean noVerified;
+	
+	/* 현재 페이지 */
+	private int pageNum;
+
+	/* 한 페이지 당 보여질 게시물 갯수 */
+	private int amount;
+	
+	// 참고) https://kimvampa.tistory.com/170,  https://kimvampa.tistory.com/173?category=843151
+
+    private int skip; 	// 스킵 할 게시물 수 의미( (pageNum-1) * amount ) 
+	// ex) 1page 에서 보여줄 게시물은 가장 최근꺼부터 (1) ~ (10)번쨰 게시글 
+	// ex) 2page 에서 보여줄 게시물은  (11)번째 게시물 부터 ~ 20 번째 게시물
+    
+    
+	/* 기본 생성자 -> 기봅 세팅 : pageNum = 1, amount = 10 */
+	public MemberOption() {
+		this(1, 10);
+	}
+
+	/* 생성자 => 원하는 pageNum, 원하는 amount */
+	public MemberOption(int pageNum, int amount) {
+		this.pageNum = pageNum;
+		this.skip = (pageNum-1) * amount;
+		this.amount = amount;
+	}
+
+	public void setpageNum(int pageNum) {
+		this.skip = (pageNum-1) * this.amount;
+		this.pageNum = pageNum;
+	}
+	
+	public void setAmount(int amount) {
+		this.skip = (this.pageNum-1) * amount;
+		this.amount = amount;
+	}
+}

--- a/ppiyung/src/main/resources/mappers/MemberMapper.xml
+++ b/ppiyung/src/main/resources/mappers/MemberMapper.xml
@@ -183,16 +183,17 @@
 	
 	<!-- 회원정보수정 -->
 	<update id="updateMember" parameterType="Member">
-		<![CDATA[ 
-			UPDATE member_tb 
-			SET 
-			member_pw= #{memberPw} , member_name=#{memberName}, member_birth= #{memberBirth},
-			member_phone = #{memberPhone}, member_addr = #{memberAddr},
-			member_coord_x = #{memberCoordX} , member_coord_y = #{memberCoordY}, member_nickname = #{memberNickname},
-			member_email =  #{memberEmail}, member_info = #{memberInfo} ,work_area_id= #{workAreaId},member_verified = #{memberVerified}
-			WHERE
-		    member_id= #{memberId}
-		]]>
+		UPDATE member_tb 
+		SET
+		<if test="memberPw != null">
+			member_pw= #{memberPw},
+		</if>
+		member_name=#{memberName}, member_birth= #{memberBirth},
+		member_phone = #{memberPhone}, member_addr = #{memberAddr},
+		member_coord_x = #{memberCoordX} , member_coord_y = #{memberCoordY}, member_nickname = #{memberNickname},
+		member_email =  #{memberEmail}, member_info = #{memberInfo} ,work_area_id= #{workAreaId},member_verified = #{memberVerified}
+		WHERE
+	    member_id= #{memberId}
 	</update>
 	
 	<!-- 회원탈퇴 기능 -->

--- a/ppiyung/src/main/resources/mappers/MemberMapper.xml
+++ b/ppiyung/src/main/resources/mappers/MemberMapper.xml
@@ -66,7 +66,7 @@
 	    <result property="resumeUpdatedAt" column="resume_updated_at" />
 	    <result property="resumeOpen" column="resume_open" />
     </resultMap>
-
+    
 	<select id="login" parameterType="Member"
 	        resultMap="MemberMapped">		
 	        
@@ -81,15 +81,54 @@
 		]]>
 	</select>
 	
+	<!-- 회원전체조회 전체 행 수-->
+	<select id="selectAllTotal" parameterType="MemberOption" resultType="_int">		
+			SELECT COUNT(*)
+			FROM member_tb
+			 <where>
+				 <if test="memberId != null">
+					 member_id = #{memberId}
+				 </if>
+				 <if test="memberType != null">
+					 AND member_type = #{memberType}
+				 </if>
+				 <if test="memberName != null">
+					 AND member_name = #{memberName}
+				 </if>
+				 <if test="memberName != null">
+					 AND member_name = #{memberName}
+				 </if>
+				 <if test="noVerified == true">
+					 AND member_verified = 0
+				 </if>
+			 </where>
+	</select>
+	
 	<!-- 회원전체조회 -->
-		<select id="selectAll" parameterType="PagingEntity"  resultMap="MemberMapped">		
-		<![CDATA[
+		<select id="selectAll" parameterType="MemberOption" resultMap="MemberMapped">		
 			SELECT member_id, member_pw, member_name, member_birth,
 					member_gender, member_phone, member_addr, member_coord_x, member_coord_y,
 					member_nickname, member_email, member_type, member_reg_num, member_info,
 					member_active, member_created_at, work_area_id, member_verified
-			FROM member_tb   ORDER BY  member_created_at DESC LIMIT #{skip}, #{amount}
-		]]>
+			FROM member_tb
+			 <where>
+				 <if test="memberId != null">
+					 member_id = #{memberId}
+				 </if>
+				 <if test="memberType != null">
+					 AND member_type = #{memberType}
+				 </if>
+				 <if test="memberName != null">
+					 AND member_name = #{memberName}
+				 </if>
+				 <if test="memberName != null">
+					 AND member_name = #{memberName}
+				 </if>
+				 <if test="noVerified == true">
+					 AND member_verified = 0
+				 </if>
+			 </where>
+			ORDER BY member_created_at DESC LIMIT #{skip}, #{amount}
 	</select>
 	
 	<!-- 개별회원조회 -->

--- a/ppiyung/src/main/resources/mybatis-config.xml
+++ b/ppiyung/src/main/resources/mybatis-config.xml
@@ -11,6 +11,7 @@
 	 <typeAliases>
 	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.Member" alias="Member"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.MemberExtended" alias="MemberExtended"/>
+	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.MemberOption" alias="MemberOption"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.OpenResumeOption" alias="OpenResumeOption"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.Image" alias="Image"/>
 	 	<typeAlias type="org.ppiyung.ppiyung.member.vo.Resume" alias="Resume"/>


### PR DESCRIPTION
- 회원 리스트 조회 고도화
- 회원 정보 수정시 비밀번호가 공란이거나 null(아예 키에 포함 안된 경우)이면 비밀번호는 수정되지 않도록 변경
- 탈퇴한 계정이거나 승인되지 않은 계정은 로그인되지 않도록 변경